### PR TITLE
use plain metric name when prefix is empty

### DIFF
--- a/src/collectors/collector.ts
+++ b/src/collectors/collector.ts
@@ -43,6 +43,10 @@ export abstract class Collector {
       ? this.commonOptions.metricsPrefix.slice(0, -1)
       : this.commonOptions.metricsPrefix
 
+    if (!prefix.length) {
+      return name
+    }
+
     return [prefix, name].join('_')
   }
 


### PR DESCRIPTION
If prefix is not defined in configuration, metrics are generated with leading underscore, such as `_http_requests_total`. This PR fix this.